### PR TITLE
New search parameter that filter collection centers only do certain test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See the [release page] for authors, detailed dates, commit hashes and available downloads.
 
+## v2.8.19 - Add new search parameter filters
+
+- **Changes:** Add new search parameter filters to support filter of collection centers that only do drug test.
+
 ## v2.8.17 - Remove locate me button if geolocation blocked
 
 - **Changes:** Remove locate me button if geolocation blocked and also change the message text for geolocation error.

--- a/js/findalab.js
+++ b/js/findalab.js
@@ -73,6 +73,7 @@
          * @property {array}  recommendedNetworks   List of networks that are recommended.
          * @property {string} filterByOrder         Filter better labs to this order transaction id.
          * @property {array}  filterByTests         Filter labs to those that can service this list of tests by key attribute (name, slug...).
+         * @property {string} filters               Filter labs that only do certain test.
          */
         searchFunction: {
           excludeNetworks: undefined,
@@ -81,7 +82,8 @@
           onlyStates: [],
           recommendedNetworks: [],
           filterByOrder: null,
-          filterByTests: { key: null, values: [] }
+          filterByTests: { key: null, values: [] },
+          filters: undefined
         },
         /**
          * Setting for the lab item in the search result.
@@ -890,6 +892,7 @@
             filterByStates: self.settings.searchFunction.onlyStates,
             filterByOrder: self.settings.searchFunction.filterByOrder,
             filterByTests: self.settings.searchFunction.filterByTests,
+            filters: self.settings.searchFunction.filters,
             labCount: self.settings.searchFunction.limit,
             network: self.settings.searchFunction.onlyNetwork,
             dayOnly: self.settings.dayOfWeekFilter.showOption ? self.settings.dayOfWeekFilter.dayOnly : ''


### PR DESCRIPTION
For https://github.com/Medology/www.starfish.com/issues/119
Add new search parameter `filters` to support the filter of collection centers that only do drug test.

I have to open a new PR , old PR is https://github.com/Medology/findalab/pull/129
medology/findalab is a public repo now , so I have to make mine public also. and After that `git push` is all messed up now.

Answers to the question under old PR are as below:

It allows multiple filters. and this is the format `&filters=[key1]%3D[value1],[key2]%3D[value2],...`
If  the paramter is an array, the url will be `&filters%5B%5D=does_drugs%3D1&filters%5B%5D=does_screening%3D1`. That's why I keep it as a string, so the output url will be like `&filters=does_drugs%3D1%2Cdoes_screening%3D1`