### PR TITLE
Make less generic the not found tests centers

### DIFF
--- a/js/findalab.js
+++ b/js/findalab.js
@@ -193,6 +193,7 @@
       this.settings.search.buttonText + '" to see results.';
 
       this.noResultsMessage = 'Oops! Sorry, we could not find any testing centers near that location. ' +
+      'Please check that the entered data is correct. ' +
       'Please try your search again with a different or less specific address.';
 
       this.cannotGeolocateMessage = 'We are unable to determine your location.<br/>' + this.emptyResultsMessage;

--- a/js/findalab.js
+++ b/js/findalab.js
@@ -194,7 +194,7 @@
 
       this.noResultsMessage = 'Oops! Sorry, we could not find any testing centers near that location. ' +
       'Please check that the entered data is correct. ' +
-      'Please try your search again with a different or less specific address.';
+      'And try your search again with a different or less specific address.';
 
       this.cannotGeolocateMessage = 'We are unable to determine your location.<br/>' + this.emptyResultsMessage;
 


### PR DESCRIPTION
Related to Issue #7739 

#### Context
In order to return a less generic message when no tests centers are found, the message should include an instruction to check the data provided. 