### PR TITLE
Fix the Map Pin for IE11

### DIFF
--- a/js/findalab.js
+++ b/js/findalab.js
@@ -230,7 +230,8 @@
 
         return {
           anchor: new google.maps.Point(24, 54),
-          url: 'data:image/svg+xml;utf-8, ' + encodeURIComponent(finalSvg)
+          url: 'data:image/svg+xml;utf-8, ' + encodeURIComponent(finalSvg),
+          scaledSize: new google.maps.Size(48, 54)
         };
       }
 
@@ -987,6 +988,7 @@
 
         vMarker = new google.maps.Marker({
           map: self.settings.googleMaps.map,
+          optimized: false,
           icon: iconMarker,
           position: location,
           title: lab.title


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/8666

This will fix the Google Map Pin problem for IE11. Source: https://stackoverflow.com/questions/20414387/google-maps-svg-marker-doesnt-display-on-ie-11 :trollface: 