### PR TITLE
Change inline SVG encode method

### DIFF
--- a/js/findalab.js
+++ b/js/findalab.js
@@ -230,7 +230,7 @@
 
         return {
           anchor: new google.maps.Point(24, 54),
-          url: 'data:image/svg+xml;utf-8, ' + encodeURIComponent(finalSvg),
+          url: 'data:image/svg+xml;base64,' + btoa(finalSvg),
           scaledSize: new google.maps.Size(48, 54)
         };
       }


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/8666

### Problem
UTF8 + URLEncoded SVG inline resource is not working in IE11

### Fix
Use base64 encoding which works for IE11