### PR TITLE
Fixate jQuery version at 3.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "cross-env": "^7.0.2",
     "findalab": "Medology/findalab",
-    "jquery": "^3.5.0"
+    "jquery": "~3.4.1"
   },
   "devDependencies": {
     "laravel-mix": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,10 +3856,15 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.4.1, jquery@^3.5.0:
+jquery@^3.4.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
   integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+
+jquery@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,7 +2923,7 @@ findalab@Medology/findalab:
   resolved "https://codeload.github.com/Medology/findalab/tar.gz/464440f8296b3c2ea4fde0b76188e7179a0e1e1d"
   dependencies:
     cross-env "^7.0.2"
-    jquery "^3.4.1"
+    jquery "~3.4.1"
 
 findup-sync@3.0.0:
   version "3.0.0"
@@ -3855,11 +3855,6 @@ jest-worker@^25.1.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
-
-jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 jquery@~3.4.1:
   version "3.4.1"


### PR DESCRIPTION
For #179 

### Problem
jQuery version 3.5.0 is causing a problem for STDCheck. So it is better to fixate the jQuery version at 3,4 for now