### PR TITLE
Removing findalab package from package.json that been mistakenly added

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import FindALab from "./dist/findalab";
-import FindALabCSS from "./dist/findalab.css";
+import findALab from "./dist/findalab";
+import findALabCSS from "./dist/findalab.css";
 
-export default FindALab;
-export {FindALab, FindALabCSS};
+export default findALab;
+export {findALab, findALabCSS};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "cross-env": "^7.0.2",
-    "findalab": "Medology/findalab",
     "jquery": "~3.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,13 +2918,6 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-findalab@Medology/findalab:
-  version "3.0.0"
-  resolved "https://codeload.github.com/Medology/findalab/tar.gz/464440f8296b3c2ea4fde0b76188e7179a0e1e1d"
-  dependencies:
-    cross-env "^7.0.2"
-    jquery "~3.4.1"
-
 findup-sync@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"


### PR DESCRIPTION
For #179 

The `findalab` itself been mistakenly added to the package.json, and that was causing an infinite loop. 