### PR TITLE
Configure Scrutinizer

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -22,3 +22,6 @@ pullapprove_conditions:
   - condition: "'ci/circleci: test' in statuses.succeeded or 'Force Review' in labels"
     unmet_status: pending
     explanation: "ci/circleci: test must pass before requesting review"
+  - condition: "'Scrutinizer: test' in statuses.succeeded or 'Force Review' in labels"
+    unmet_status: pending
+    explanation: "Scrutinizer: test must pass before requesting review"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -22,6 +22,6 @@ pullapprove_conditions:
   - condition: "'ci/circleci: test' in statuses.succeeded or 'Force Review' in labels"
     unmet_status: pending
     explanation: "ci/circleci: test must pass before requesting review"
-  - condition: "'Scrutinizer: test' in statuses.succeeded or 'Force Review' in labels"
+  - condition: "'Scrutinizer' in statuses.succeeded or 'Force Review' in labels"
     unmet_status: pending
-    explanation: "Scrutinizer: test must pass before requesting review"
+    explanation: "Scrutinizer must pass before requesting review"

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -28,4 +28,4 @@ checks:
 build_failure_conditions:
   - 'elements.rating(< A).new.exists'            # No new classes/methods with a rating below A
   - 'issues.new.exists'                          # No new issues
-  - 'project.metric("scrutinizer.quality", < 8)' # Code Quality Rating drops below 8
+  - 'project.metric("scrutinizer.quality", < 3.21)' # Code Quality Rating drops below 8

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,19 +1,31 @@
 build:
   nodes:
     analysis:
-      environment:
-        php:
-          version: 5.5.9
-      project_setup:
-        override:
-          - 'true'
       tests:
         override:
           - php-scrutinizer-run
+          - phpcs-run
+          - js-scrutinizer-run
+  environment:
+    php:
+      version: 7.0.33
+  dependencies:
+    override:
+      - git config --global url.git@github.com:.insteadOf git://github.com/
+      - composer install --ignore-platform-reqs --no-interaction --no-scripts
+
+filter:
+  excluded_paths:
+    - ".idea/"
+  dependency_paths:
+    - "dev/vendor/"
+    - "node_modules/"
+    -
 checks:
   php: true
-coding_style:
-  php:
-    spaces:
-      around_operators:
-        concatenation: true
+  javascript: true
+
+build_failure_conditions:
+  - 'elements.rating(< A).new.exists'            # No new classes/methods with a rating below A
+  - 'issues.new.exists'                          # No new issues
+  - 'project.metric("scrutinizer.quality", < 8)' # Code Quality Rating drops below 8

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+  <description>The coding standard for our project.</description>
+  <rule ref="PSR2"/>
+
+  <!--
+      Check all files/folders
+  -->
+  <file>.</file>
+
+
+  <!--
+  Exclude files
+  -->
+  <exclude-pattern>_ide_helper.php</exclude-pattern>
+  <exclude-pattern>*.blade.php</exclude-pattern>
+  <exclude-pattern>*.css</exclude-pattern>
+  <exclude-pattern>*.js</exclude-pattern>
+
+  <!--
+      Exclude folders
+  -->
+  <exclude-pattern>.circleci/*</exclude-pattern>
+  <exclude-pattern>.idea/*</exclude-pattern>
+  <exclude-pattern>.github/*</exclude-pattern>
+  <exclude-pattern>artifacts/*</exclude-pattern>
+  <exclude-pattern>bin/*</exclude-pattern>
+  <exclude-pattern>docker/*</exclude-pattern>
+  <exclude-pattern>node_modules/*</exclude-pattern>
+  <exclude-pattern>dev/vendor/*</exclude-pattern>
+
+  <arg name="report" value="summary"/>
+  <arg name="colors"/>
+  <arg value="sp"/>
+
+  <ini name="memory_limit" value="128M"/>
+</ruleset>


### PR DESCRIPTION
For: #291 

Sets up Scrutinizer on the project.

Currently, the codebase has failed conditions. This issue is only to enable Scrutinizer on the project.
Scrutinizer is not set as a required check yet, so it will not block anybody.
After this PR it should only fail if new issues are introduced. In the case it does not pass on other PRs after this one then I will work on getting the codebase above an F before making it a required check.
